### PR TITLE
Use full page width for the svg diagram

### DIFF
--- a/calc.jsx
+++ b/calc.jsx
@@ -65,7 +65,7 @@ update = function(props) {
 
 var Graph = React.createClass({
     render: function() {
-        return <svg width="960" height="600"></svg>;
+        return <svg width="100%" height="600"></svg>;
     },
     componentDidMount: function () {
         d3.select(this.getDOMNode())


### PR DESCRIPTION
This avoids an issue where large diagrams are cropped horizontally,
even though more horizontal space is available.

Example: science-pack-3
